### PR TITLE
diaryListVC 구현

### DIFF
--- a/KIDA/KIDA.xcodeproj/project.pbxproj
+++ b/KIDA/KIDA.xcodeproj/project.pbxproj
@@ -24,6 +24,11 @@
 		ED20E00F27957407004951E1 /* DiaryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED20E00E27957407004951E1 /* DiaryListViewController.swift */; };
 		ED20E01127957416004951E1 /* DiaryListViewReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED20E01027957416004951E1 /* DiaryListViewReactor.swift */; };
 		ED20E015279574A8004951E1 /* DiaryListCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED20E014279574A8004951E1 /* DiaryListCoordinator.swift */; };
+		ED20E017279575E4004951E1 /* BaseTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED20E016279575E4004951E1 /* BaseTableViewCell.swift */; };
+		ED20E01A279577E8004951E1 /* DiaryListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED20E019279577E8004951E1 /* DiaryListCell.swift */; };
+		ED20E01C279577F0004951E1 /* DiaryListCellReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED20E01B279577F0004951E1 /* DiaryListCellReactor.swift */; };
+		ED20E01F27957946004951E1 /* ReuseCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED20E01E27957946004951E1 /* ReuseCell.swift */; };
+		ED20E02227957B52004951E1 /* DiayListSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED20E02127957B52004951E1 /* DiayListSection.swift */; };
 		ED26F2D42792C7F1005EE53A /* ReactorKit in Frameworks */ = {isa = PBXBuildFile; productRef = ED26F2D32792C7F1005EE53A /* ReactorKit */; };
 		ED26F2D72792C827005EE53A /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = ED26F2D62792C827005EE53A /* SnapKit */; };
 		ED26F2DA2792C8CD005EE53A /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = ED26F2D92792C8CD005EE53A /* Then */; };
@@ -52,6 +57,11 @@
 		ED20E00E27957407004951E1 /* DiaryListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListViewController.swift; sourceTree = "<group>"; };
 		ED20E01027957416004951E1 /* DiaryListViewReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListViewReactor.swift; sourceTree = "<group>"; };
 		ED20E014279574A8004951E1 /* DiaryListCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListCoordinator.swift; sourceTree = "<group>"; };
+		ED20E016279575E4004951E1 /* BaseTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTableViewCell.swift; sourceTree = "<group>"; };
+		ED20E019279577E8004951E1 /* DiaryListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListCell.swift; sourceTree = "<group>"; };
+		ED20E01B279577F0004951E1 /* DiaryListCellReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListCellReactor.swift; sourceTree = "<group>"; };
+		ED20E01E27957946004951E1 /* ReuseCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReuseCell.swift; sourceTree = "<group>"; };
+		ED20E02127957B52004951E1 /* DiayListSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiayListSection.swift; sourceTree = "<group>"; };
 		ED26F2E22792CA19005EE53A /* HomeViewReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewReactor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -75,6 +85,7 @@
 			isa = PBXGroup;
 			children = (
 				86FABE092792B002001D986C /* BaseViewController.swift */,
+				ED20E016279575E4004951E1 /* BaseTableViewCell.swift */,
 				86FABE052792AF5F001D986C /* Protocols */,
 			);
 			path = Base;
@@ -108,6 +119,7 @@
 		86FABDEA2792AEB2001D986C /* KIDA */ = {
 			isa = PBXGroup;
 			children = (
+				ED20E02027957B39004951E1 /* Type */,
 				86FABE022792AEB9001D986C /* App */,
 				86FABE042792AEEA001D986C /* Sources */,
 				86FABDF72792AEB3001D986C /* Assets.xcassets */,
@@ -142,6 +154,7 @@
 			children = (
 				86FABE072792AFD1001D986C /* Coordinatable.swift */,
 				8644830027930EFC0020F782 /* ServiceDependency.swift */,
+				ED20E01E27957946004951E1 /* ReuseCell.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -170,10 +183,28 @@
 		ED20E00D279573ED004951E1 /* DiaryList */ = {
 			isa = PBXGroup;
 			children = (
+				ED20E018279577CE004951E1 /* Cells */,
 				ED20E00E27957407004951E1 /* DiaryListViewController.swift */,
 				ED20E01027957416004951E1 /* DiaryListViewReactor.swift */,
 			);
 			path = DiaryList;
+			sourceTree = "<group>";
+		};
+		ED20E018279577CE004951E1 /* Cells */ = {
+			isa = PBXGroup;
+			children = (
+				ED20E019279577E8004951E1 /* DiaryListCell.swift */,
+				ED20E01B279577F0004951E1 /* DiaryListCellReactor.swift */,
+			);
+			path = Cells;
+			sourceTree = "<group>";
+		};
+		ED20E02027957B39004951E1 /* Type */ = {
+			isa = PBXGroup;
+			children = (
+				ED20E02127957B52004951E1 /* DiayListSection.swift */,
+			);
+			path = Type;
 			sourceTree = "<group>";
 		};
 		ED26F2E12792CA08005EE53A /* Home */ = {
@@ -269,6 +300,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ED20E02227957B52004951E1 /* DiayListSection.swift in Sources */,
 				86FABDF02792AEB2001D986C /* HomeViewController.swift in Sources */,
 				ED20E01127957416004951E1 /* DiaryListViewReactor.swift in Sources */,
 				8644830A279310CB0020F782 /* SelectedKeywordReactor.swift in Sources */,
@@ -276,11 +308,15 @@
 				ED26F2E32792CA19005EE53A /* HomeViewReactor.swift in Sources */,
 				86FABE082792AFD1001D986C /* Coordinatable.swift in Sources */,
 				8644830127930EFC0020F782 /* ServiceDependency.swift in Sources */,
+				ED20E01A279577E8004951E1 /* DiaryListCell.swift in Sources */,
 				ED20E00F27957407004951E1 /* DiaryListViewController.swift in Sources */,
 				86FABDF62792AEB2001D986C /* KIDA.xcdatamodeld in Sources */,
 				86FABDEE2792AEB2001D986C /* SceneDelegate.swift in Sources */,
+				ED20E01C279577F0004951E1 /* DiaryListCellReactor.swift in Sources */,
 				86448308279310C30020F782 /* selectedKeywordViewController.swift in Sources */,
 				86FABE0F2792B107001D986C /* HomeCoordinator.swift in Sources */,
+				ED20E01F27957946004951E1 /* ReuseCell.swift in Sources */,
+				ED20E017279575E4004951E1 /* BaseTableViewCell.swift in Sources */,
 				86FABE0A2792B002001D986C /* BaseViewController.swift in Sources */,
 				864483052793106C0020F782 /* SelectedKeywordCoordinator.swift in Sources */,
 				ED20E015279574A8004951E1 /* DiaryListCoordinator.swift in Sources */,

--- a/KIDA/KIDA.xcodeproj/project.pbxproj
+++ b/KIDA/KIDA.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 		86FABE0A2792B002001D986C /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86FABE092792B002001D986C /* BaseViewController.swift */; };
 		86FABE0D2792B097001D986C /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86FABE0C2792B097001D986C /* AppCoordinator.swift */; };
 		86FABE0F2792B107001D986C /* HomeCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86FABE0E2792B107001D986C /* HomeCoordinator.swift */; };
+		ED20E00F27957407004951E1 /* DiaryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED20E00E27957407004951E1 /* DiaryListViewController.swift */; };
+		ED20E01127957416004951E1 /* DiaryListViewReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED20E01027957416004951E1 /* DiaryListViewReactor.swift */; };
+		ED20E015279574A8004951E1 /* DiaryListCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED20E014279574A8004951E1 /* DiaryListCoordinator.swift */; };
 		ED26F2D42792C7F1005EE53A /* ReactorKit in Frameworks */ = {isa = PBXBuildFile; productRef = ED26F2D32792C7F1005EE53A /* ReactorKit */; };
 		ED26F2D72792C827005EE53A /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = ED26F2D62792C827005EE53A /* SnapKit */; };
 		ED26F2DA2792C8CD005EE53A /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = ED26F2D92792C8CD005EE53A /* Then */; };
@@ -46,6 +49,9 @@
 		86FABE092792B002001D986C /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		86FABE0C2792B097001D986C /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		86FABE0E2792B107001D986C /* HomeCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCoordinator.swift; sourceTree = "<group>"; };
+		ED20E00E27957407004951E1 /* DiaryListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListViewController.swift; sourceTree = "<group>"; };
+		ED20E01027957416004951E1 /* DiaryListViewReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListViewReactor.swift; sourceTree = "<group>"; };
+		ED20E014279574A8004951E1 /* DiaryListCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiaryListCoordinator.swift; sourceTree = "<group>"; };
 		ED26F2E22792CA19005EE53A /* HomeViewReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewReactor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -143,6 +149,7 @@
 		86FABE062792AF61001D986C /* Scene */ = {
 			isa = PBXGroup;
 			children = (
+				ED20E00D279573ED004951E1 /* DiaryList */,
 				86448306279310B90020F782 /* SelectedKeyword */,
 				ED26F2E12792CA08005EE53A /* Home */,
 			);
@@ -155,8 +162,18 @@
 				86FABE0C2792B097001D986C /* AppCoordinator.swift */,
 				86FABE0E2792B107001D986C /* HomeCoordinator.swift */,
 				864483042793106C0020F782 /* SelectedKeywordCoordinator.swift */,
+				ED20E014279574A8004951E1 /* DiaryListCoordinator.swift */,
 			);
 			path = Coordinators;
+			sourceTree = "<group>";
+		};
+		ED20E00D279573ED004951E1 /* DiaryList */ = {
+			isa = PBXGroup;
+			children = (
+				ED20E00E27957407004951E1 /* DiaryListViewController.swift */,
+				ED20E01027957416004951E1 /* DiaryListViewReactor.swift */,
+			);
+			path = DiaryList;
 			sourceTree = "<group>";
 		};
 		ED26F2E12792CA08005EE53A /* Home */ = {
@@ -253,17 +270,20 @@
 			buildActionMask = 2147483647;
 			files = (
 				86FABDF02792AEB2001D986C /* HomeViewController.swift in Sources */,
+				ED20E01127957416004951E1 /* DiaryListViewReactor.swift in Sources */,
 				8644830A279310CB0020F782 /* SelectedKeywordReactor.swift in Sources */,
 				86FABDEC2792AEB2001D986C /* AppDelegate.swift in Sources */,
 				ED26F2E32792CA19005EE53A /* HomeViewReactor.swift in Sources */,
 				86FABE082792AFD1001D986C /* Coordinatable.swift in Sources */,
 				8644830127930EFC0020F782 /* ServiceDependency.swift in Sources */,
+				ED20E00F27957407004951E1 /* DiaryListViewController.swift in Sources */,
 				86FABDF62792AEB2001D986C /* KIDA.xcdatamodeld in Sources */,
 				86FABDEE2792AEB2001D986C /* SceneDelegate.swift in Sources */,
 				86448308279310C30020F782 /* selectedKeywordViewController.swift in Sources */,
 				86FABE0F2792B107001D986C /* HomeCoordinator.swift in Sources */,
 				86FABE0A2792B002001D986C /* BaseViewController.swift in Sources */,
 				864483052793106C0020F782 /* SelectedKeywordCoordinator.swift in Sources */,
+				ED20E015279574A8004951E1 /* DiaryListCoordinator.swift in Sources */,
 				86FABE0D2792B097001D986C /* AppCoordinator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/KIDA/KIDA/Sources/Base/BaseTableViewCell.swift
+++ b/KIDA/KIDA/Sources/Base/BaseTableViewCell.swift
@@ -1,0 +1,22 @@
+//
+//  BaseTableViewCell.swift
+//  KIDA
+//
+//  Created by choidam on 2022/01/17.
+//
+
+import UIKit
+
+class BaseTableViewCell<R: Reactor>: UITableViewCell, ReactorKit.View {
+    typealias Reactor = R
+    
+    var disposeBag = DisposeBag()
+    
+    override class func awakeFromNib() {
+        super.awakeFromNib()
+    }
+    
+    func bind(reactor: R) {
+        
+    }
+}

--- a/KIDA/KIDA/Sources/Base/BaseViewController.swift
+++ b/KIDA/KIDA/Sources/Base/BaseViewController.swift
@@ -38,5 +38,9 @@ class BaseViewController: UIViewController {
     func setupLayoutConstraints() {
         // Override Constraints.
     }
+    
+    deinit {
+        print("deinit : \(self)")
+    }
 
 }

--- a/KIDA/KIDA/Sources/Base/Protocols/ReuseCell.swift
+++ b/KIDA/KIDA/Sources/Base/Protocols/ReuseCell.swift
@@ -1,0 +1,58 @@
+//
+//  ReuseCell.swift
+//  KIDA
+//
+//  Created by choidam on 2022/01/17.
+//
+
+import UIKit
+
+protocol CellType: class {
+    var reuseIdentifier: String? { get }
+}
+
+struct ReuseCell<Cell: CellType> {
+    typealias Class = Cell
+    
+    let `class`: Class.Type = Class.self
+    let identifier: String
+    let nib: UINib?
+    
+    private init(identifier: String? = nil, nib: UINib? = nil) {
+        self.identifier = nib?.instantiate(withOwner: nil, options: nil).lazy
+            .compactMap { ($0 as? CellType)?.reuseIdentifier }
+            .first ?? identifier ?? UUID().uuidString
+        self.nib = nib
+    }
+    
+    init(identifier: String? = nil) {
+        if Bundle.main.path(forResource: String(describing: Cell.self), ofType: "nib") != nil {
+            let nib = UINib(nibName: String(describing: Cell.self), bundle: nil)
+            self.init(identifier: identifier, nib: nib)
+        } else {
+            self.init(identifier: identifier, nib: nil)
+        }
+    }
+}
+
+extension UITableViewCell: CellType {
+    
+}
+
+extension UITableView {
+    func register<Cell>(_ cell: ReuseCell<Cell>) {
+        if let nib = cell.nib {
+            self.register(nib, forCellReuseIdentifier: cell.identifier)
+        } else {
+            self.register(Cell.self, forCellReuseIdentifier: cell.identifier)
+        }
+    }
+    
+    func dequeue<Cell>(_ cell: ReuseCell<Cell>) -> Cell? {
+        return self.dequeueReusableCell(withIdentifier: cell.identifier) as? Cell
+    }
+    
+    func dequeue<Cell>(_ cell: ReuseCell<Cell>, for indexPath: IndexPath) -> Cell {
+        return self.dequeueReusableCell(withIdentifier: cell.identifier, for: indexPath) as! Cell
+     }
+}

--- a/KIDA/KIDA/Sources/Coordinators/DiaryListCoordinator.swift
+++ b/KIDA/KIDA/Sources/Coordinators/DiaryListCoordinator.swift
@@ -1,0 +1,30 @@
+//
+//  DiaryListCoordinator.swift
+//  KIDA
+//
+//  Created by choidam on 2022/01/17.
+//
+
+import UIKit
+
+final class DiaryListCoordinator: Coordinatable {
+
+    // MARK: - Properties
+    var childCoordinators: [Coordinatable] = []
+    var parentCoordinator: Coordinatable?
+    var navigationController: UINavigationController
+
+    // MARK: - Initializer
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+
+    // MARK: - Methods
+    func start() {
+        let diaryListReactor = DiaryListViewReactor()
+        let diaryListViewController = DiaryListViewController()
+        diaryListViewController.reactor = diaryListReactor
+        navigationController.viewControllers = [diaryListViewController]
+    }
+}
+

--- a/KIDA/KIDA/Sources/Coordinators/HomeCoordinator.swift
+++ b/KIDA/KIDA/Sources/Coordinators/HomeCoordinator.swift
@@ -22,7 +22,8 @@ final class HomeCoordinator: Coordinatable {
     // MARK: - Methods
     func start() {
         let homeViewReactor = HomeViewReactor()
-        let homeViewController = HomeViewController(reactor: homeViewReactor)
+        let homeViewController = HomeViewController()
+        homeViewController.reactor = homeViewReactor
         navigationController.viewControllers = [homeViewController]
     }
 }

--- a/KIDA/KIDA/Sources/Scene/DiaryList/Cells/DiaryListCell.swift
+++ b/KIDA/KIDA/Sources/Scene/DiaryList/Cells/DiaryListCell.swift
@@ -1,0 +1,50 @@
+//
+//  DiaryListCell.swift
+//  KIDA
+//
+//  Created by choidam on 2022/01/17.
+//
+
+import UIKit
+
+final class DiaryListCell: BaseTableViewCell<DiaryListCellReactor> {
+    
+    // MARK: UI
+    
+    private let titleLabel = UILabel()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        setupLayoutConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func bind(reactor: DiaryListCellReactor) {
+        reactor.state
+            .map { $0.title }
+            .bind(to: titleLabel.rx.text)
+            .disposed(by: disposeBag)
+    }
+    
+}
+
+extension DiaryListCell {
+    private func setupViews() {
+        titleLabel.textColor = .black
+        titleLabel.font = UIFont.systemFont(ofSize: 15)
+        addSubview(titleLabel)
+    }
+
+    private func setupLayoutConstraints() {
+        setupViews()
+        
+        titleLabel.snp.makeConstraints {
+            $0.leading.equalTo(10)
+            $0.centerY.equalToSuperview()
+        }
+    }
+}

--- a/KIDA/KIDA/Sources/Scene/DiaryList/Cells/DiaryListCellReactor.swift
+++ b/KIDA/KIDA/Sources/Scene/DiaryList/Cells/DiaryListCellReactor.swift
@@ -1,0 +1,21 @@
+//
+//  DiaryListCellReactor.swift
+//  KIDA
+//
+//  Created by choidam on 2022/01/17.
+//
+
+final class DiaryListCellReactor: Reactor {
+    typealias Action = NoAction
+
+    struct State {
+        var title: String
+    }
+    
+    var initialState: State
+
+    init(title: String){
+        initialState = State(title: title)
+    }
+}
+

--- a/KIDA/KIDA/Sources/Scene/DiaryList/DiaryListViewController.swift
+++ b/KIDA/KIDA/Sources/Scene/DiaryList/DiaryListViewController.swift
@@ -48,7 +48,7 @@ final class DiaryListViewController: BaseViewController, ServiceDependency {
     override func setupLayoutConstraints() {
         
         tableView.snp.makeConstraints {
-            $0.leading.trailing.top.bottom.equalTo(0)
+            $0.edges.equalTo(0)
         }
     }
 
@@ -58,7 +58,7 @@ final class DiaryListViewController: BaseViewController, ServiceDependency {
     }
 }
 
-extension DiaryListViewController {
+private extension DiaryListViewController {
 
     func bindState(reactor: DiaryListViewReactor){
         

--- a/KIDA/KIDA/Sources/Scene/DiaryList/DiaryListViewController.swift
+++ b/KIDA/KIDA/Sources/Scene/DiaryList/DiaryListViewController.swift
@@ -1,0 +1,39 @@
+//
+//  DiaryListViewController.swift
+//  KIDA
+//
+//  Created by choidam on 2022/01/17.
+//
+
+final class DiaryListViewController: BaseViewController, ServiceDependency {
+
+    // MARK: UI
+
+    // MARK: Property
+    
+    var reactor: DiaryListViewReactor?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    override func setupViews() {
+    }
+
+    override func setupLayoutConstraints() {
+    }
+
+    func bind(reactor: DiaryListViewReactor) {
+        bindState(reactor: reactor)
+        bindAction(reactor: reactor)
+    }
+}
+
+extension DiaryListViewController {
+
+    func bindState(reactor: DiaryListViewReactor){
+    }
+
+    func bindAction(reactor: DiaryListViewReactor){
+    }
+}

--- a/KIDA/KIDA/Sources/Scene/DiaryList/DiaryListViewController.swift
+++ b/KIDA/KIDA/Sources/Scene/DiaryList/DiaryListViewController.swift
@@ -5,11 +5,33 @@
 //  Created by choidam on 2022/01/17.
 //
 
+import UIKit
+import RxDataSources
+
 final class DiaryListViewController: BaseViewController, ServiceDependency {
 
     // MARK: UI
-
+    
+    fileprivate struct Reuse {
+        static let diaryListCell = ReuseCell<DiaryListCell>()
+    }
+    
+    private lazy var tableView = UITableView()
+    
     // MARK: Property
+    
+    private static func dataSourceFactory() -> RxTableViewSectionedReloadDataSource<DiaryListSection>{
+        return .init(configureCell: { dataSource, tableView, indexPath, sectionItem in
+            switch sectionItem {
+            case .item(let reactor):
+                let cell = tableView.dequeue(Reuse.diaryListCell, for: indexPath)
+                cell.reactor = reactor
+                return cell
+            }
+        })
+    }
+    
+    fileprivate var dataSource = DiaryListViewController.dataSourceFactory()
     
     var reactor: DiaryListViewReactor?
 
@@ -18,9 +40,16 @@ final class DiaryListViewController: BaseViewController, ServiceDependency {
     }
 
     override func setupViews() {
+        tableView.register(Reuse.diaryListCell)
+        view.addSubview(tableView)
+        
     }
 
     override func setupLayoutConstraints() {
+        
+        tableView.snp.makeConstraints {
+            $0.leading.trailing.top.bottom.equalTo(0)
+        }
     }
 
     func bind(reactor: DiaryListViewReactor) {
@@ -32,6 +61,13 @@ final class DiaryListViewController: BaseViewController, ServiceDependency {
 extension DiaryListViewController {
 
     func bindState(reactor: DiaryListViewReactor){
+        
+        reactor.state
+            .map { $0.sections }
+            .filter { !$0.isEmpty }
+            .bind(to: tableView.rx.items(dataSource: dataSource))
+            .disposed(by: disposeBag)
+        
     }
 
     func bindAction(reactor: DiaryListViewReactor){

--- a/KIDA/KIDA/Sources/Scene/DiaryList/DiaryListViewReactor.swift
+++ b/KIDA/KIDA/Sources/Scene/DiaryList/DiaryListViewReactor.swift
@@ -1,0 +1,20 @@
+//
+//  DiaryListViewReactor.swift
+//  KIDA
+//
+//  Created by choidam on 2022/01/17.
+//
+
+final class DiaryListViewReactor: Reactor {
+    typealias Action = NoAction
+
+    struct State {
+    }
+    
+    let initialState: State
+
+    init(){
+        initialState = State()
+    }
+}
+

--- a/KIDA/KIDA/Sources/Scene/DiaryList/DiaryListViewReactor.swift
+++ b/KIDA/KIDA/Sources/Scene/DiaryList/DiaryListViewReactor.swift
@@ -9,12 +9,16 @@ final class DiaryListViewReactor: Reactor {
     typealias Action = NoAction
 
     struct State {
+        var sections: [DiaryListSection] = []
     }
     
-    let initialState: State
+    var initialState: State = State()
 
     init(){
-        initialState = State()
+        
+        // test
+        initialState.sections = [.section([.item(DiaryListCellReactor(title: "sample1")), .item(DiaryListCellReactor(title: "sample2")), .item(DiaryListCellReactor(title: "sample3"))])]
+        
     }
 }
 

--- a/KIDA/KIDA/Sources/Scene/Home/HomeViewController.swift
+++ b/KIDA/KIDA/Sources/Scene/Home/HomeViewController.swift
@@ -10,41 +10,21 @@ import UIKit
 final class HomeViewController: BaseViewController, ServiceDependency {
 
     // MARK: UI
-    
-    private let testButton = UIButton()
-    
-    
+
     // MARK: Property
     
-    private var reactor: HomeViewReactor
-
-    init(reactor: HomeViewReactor) {
-        self.reactor = reactor
-
-        super.init(nibName: nil, bundle: nil)
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
+    var reactor: HomeViewReactor?
 
     override func viewDidLoad() {
         super.viewDidLoad()
     }
 
     override func setupViews() {
-        testButton.setTitle("testButton", for: .normal)
-        testButton.setTitleColor(.black, for: .normal)
-        view.addSubview(testButton)
     }
 
     override func setupLayoutConstraints() {
-        testButton.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
-            $0.centerX.equalToSuperview()
-        }
     }
-    
+
     func bind(reactor: HomeViewReactor) {
         bindState(reactor: reactor)
         bindAction(reactor: reactor)
@@ -54,13 +34,6 @@ final class HomeViewController: BaseViewController, ServiceDependency {
 extension HomeViewController {
 
     func bindState(reactor: HomeViewReactor){
-
-        testButton.rx.tap
-            .subscribe(onNext: { [weak self] _ in
-                self?.view.backgroundColor = .yellow
-            })
-            .disposed(by: disposeBag)
-
     }
 
     func bindAction(reactor: HomeViewReactor){

--- a/KIDA/KIDA/Type/DiayListSection.swift
+++ b/KIDA/KIDA/Type/DiayListSection.swift
@@ -1,0 +1,30 @@
+//
+//  DiayListSection.swift
+//  KIDA
+//
+//  Created by choidam on 2022/01/17.
+//
+
+import RxDataSources
+
+enum DiaryListSection {
+    case section([DiaryListSectionItem])
+}
+
+extension DiaryListSection: SectionModelType {
+    var items: [DiaryListSectionItem] {
+        switch self {
+        case .section(let items): return items
+        }
+    }
+    
+    init(original: DiaryListSection, items: [DiaryListSectionItem]) {
+        switch original {
+        case .section: self = .section(items)
+        }
+    }
+}
+
+enum DiaryListSectionItem {
+    case item(DiaryListCellReactor)
+}


### PR DESCRIPTION
### 작업 내역
- `BaseTableViewCell` 추가
- `ReuseCell` 추가
- `DiaryListSection` 추가
- `diaryListViewController` 추가
- `BaseViewController` 에 `deinit` 함수 추가
- `homeVC` 의 testButton 제거

### 주의사항
- 코디네이터에서 뷰컨 초기화 할 때 `init(reactor: Reactor)` 으로 reactor을 등록하면 제대로 동작이 이루어지지 않아서 수정했습니다 ㅠㅡㅠ 뷰컨을 생성하고 리액터를 붙여야 할 것 같습니다. 제 생각엔 타이밍 문제 같은데 정확한 이유는,, 찾아보도록 하겠슴다 ,, ㅎ

### 관련 이슈
- [일기 리스트 뷰 구현](https://github.com/Nexters/KIDA_iOS/issues/2)